### PR TITLE
Monitoreo automático al iniciar NVDA

### DIFF
--- a/addon/globalPlugins/battery_check/__init__.py
+++ b/addon/globalPlugins/battery_check/__init__.py
@@ -69,7 +69,7 @@ class GlobalPlugin (globalPluginHandler.GlobalPlugin):
 
 		# Se verifica la opción de monitoreo cuando NVDA se inicia. Si el usuario la activó, empezará la acción.
 		if config.conf["battery_check"]["AutoMonitor"]:
-			self.startMonitoring()
+			self.startMonitoring(True) # Agregamos True como argumento para evitar mensajes de aviso del monitoreo al iniciar.
 
 	def terminate(self):
 		"""
@@ -78,14 +78,14 @@ class GlobalPlugin (globalPluginHandler.GlobalPlugin):
 		self.stopMonitoring()
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(battery_check_Settings)
 
-	def startMonitoring(self):
+	def startMonitoring(self, quiet=False):
 		"""
 		Método que ejecuta la acción de iniciar el monitoreo de la batería.
 		"""
 		battery = psutil.sensors_battery() #Se crea una instancia de sensors_battery para verificar si existe batería en el sistema.
 		if battery is None: #Si no es así se emite un mensaje y se detiene la ejecución del método.
 			#Translators: Message to inform the user that there is no battery in the system.
-			ui.message(_("No hay batería del sistema."))
+			if not quiet: ui.message(_("No hay batería del sistema."))
 			return
 
 		if not self.monitoring: #Se verifica si el monitoreo no está activado para si es así, iniciarlo.
@@ -93,9 +93,9 @@ class GlobalPlugin (globalPluginHandler.GlobalPlugin):
 			self.monitoringThread = threading.Thread(target=self.checkBattery)
 			self.monitoringThread.start()
 			#Translators: Message to indicate that battery monitoring has started.
-			ui.message(_("Monitoreo de la batería iniciado."))
+			if not quiet: ui.message(_("Monitoreo de la batería iniciado."))
 
-	def stopMonitoring(self):
+	def stopMonitoring(self, quiet=False):
 		"""
 		Método que ejecuta la acción de detener el monitoreo de la batería.
 		"""
@@ -107,7 +107,7 @@ class GlobalPlugin (globalPluginHandler.GlobalPlugin):
 				self.stopThread = False
 
 			#Translators: Message to indicate that battery monitoring has finished.
-			ui.message(_("Monitoreo de la batería finalizado."))
+			if not quiet: ui.message(_("Monitoreo de la batería finalizado."))
 
 	def checkBattery(self):
 		"""

--- a/addon/globalPlugins/battery_check/settings.py
+++ b/addon/globalPlugins/battery_check/settings.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2024 Mateo Cedillo <angelitomateocedillo@gmail.com>
+# This file is covered by the GNU General Public License.
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# imports:
+from gui import guiHelper
+# To support future NVDA versions with API updates.
+from gui.settingsDialogs import SettingsPanel
+import wx
+import config
+import addonHandler
+
+addonHandler.initTranslation()
+
+class battery_check_Settings(SettingsPanel):
+	title = _("Battery Check")
+	def makeSettings(self, settingsSizer):
+		Helper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		self.AutoMonitor = Helper.addItem(wx.CheckBox(self, label=_("Monitorear la batería cuando inicie NVDA")))
+		self.AutoMonitor.SetValue(config.conf["battery_check"]["AutoMonitor"])
+
+	def onSave(self):
+		config.conf["battery_check"]["AutoMonitor"] = self.AutoMonitor.GetValue()


### PR DESCRIPTION
## descripción

Este PR agrega la posibilidad de que el usuario configure si el monitoreo se ejecutará al inicio de NVDA, agregando una categoría en la ventana de opciones.

Hay que señalar que, si el monitoreo se inicia y la pc no está enchufada, el monitoreo se detendrá al instante de haber empezado.